### PR TITLE
Use builder image in CI tests

### DIFF
--- a/ci/workflows/smoke.workflow
+++ b/ci/workflows/smoke.workflow
@@ -3,7 +3,7 @@ workflow "smoke tests" {
 }
 
 action "build skyhook cls" {
-  uses = "popperized/ceph-builder:skyhook-bionic"
+  uses = "docker://popperized/ceph-builder:skyhook-bionic"
   args = "cls_tabular run-query ceph_test_skyhook_query"
   env = {
     CMAKE_FLAGS = "-DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_RBD=OFF -DWITH_CEPHFS=OFF -DWITH_RADOSGW=OFF -DWITH_LEVELDB=OFF -DWITH_MANPAGE=OFF -DWITH_RDMA=OFF -DWITH_OPENLDAP=OFF -DWITH_FUSE=OFF -DWITH_LIBCEPHFS=OFF -DWITH_KRBD=OFF -DWITH_LTTNG=OFF -DWITH_BABELTRACE=OFF -DWITH_SYSTEMD=OFF -DWITH_SPDK=OFF -DWITH_CCACHE=ON -DBOOST_J=4"

--- a/ci/workflows/smoke.workflow
+++ b/ci/workflows/smoke.workflow
@@ -3,13 +3,11 @@ workflow "smoke tests" {
 }
 
 action "build skyhook cls" {
-  uses = "popperized/cmake@ubuntu-18.04"
+  uses = "popperized/ceph-builder:skyhook-bionic"
   args = "cls_tabular run-query ceph_test_skyhook_query"
   env = {
-    CMAKE_PROJECT_DIR = "./"
-    CMAKE_INSTALL_DEPS_SCRIPT = "install-deps.sh"
-    CMAKE_FLAGS = "-DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_RBD=OFF -DWITH_CEPHFS=OFF -DWITH_RADOSGW=OFF -DWITH_LEVELDB=OFF -DWITH_MANPAGE=OFF -DWITH_RDMA=OFF -DWITH_OPENLDAP=OFF -DWITH_FUSE=OFF -DWITH_LIBCEPHFS=OFF -DWITH_KRBD=OFF -DWITH_LTTNG=OFF -DWITH_BABELTRACE=OFF -DWITH_SYSTEMD=OFF -DWITH_SPDK=OFF -DWITH_CCACHE=ON -DBOOST_J=2"
-    CMAKE_BUILD_THREADS = "2"
+    CMAKE_FLAGS = "-DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_RBD=OFF -DWITH_CEPHFS=OFF -DWITH_RADOSGW=OFF -DWITH_LEVELDB=OFF -DWITH_MANPAGE=OFF -DWITH_RDMA=OFF -DWITH_OPENLDAP=OFF -DWITH_FUSE=OFF -DWITH_LIBCEPHFS=OFF -DWITH_KRBD=OFF -DWITH_LTTNG=OFF -DWITH_BABELTRACE=OFF -DWITH_SYSTEMD=OFF -DWITH_SPDK=OFF -DWITH_CCACHE=ON -DBOOST_J=4"
+    BUILD_THREADS = "4"
   }
 }
 
@@ -20,7 +18,7 @@ action "download test data" {
 }
 
 # build an image with upstream ceph-mon/ceph-osd packages and add skyhook
-# runtime dependencies such as libarrow and libhdf5
+# runtime dependencies such as libarrow, libhdf5, etc
 action "build ceph image" {
   needs = "download test data"
   uses = "actions/docker/cli@master"


### PR DESCRIPTION
a bit more of speedup for CI builds by using an already-built image. Source is available at https://github.com/systemslab/ceph-builder