### PR TITLE
Fix unused variable warning

### DIFF
--- a/src/cls/tabular/cls_tabular_utils.cc
+++ b/src/cls/tabular/cls_tabular_utils.cc
@@ -700,7 +700,7 @@ int processArrowCol(
 
                         // extract list builder as int32 builder
                         arrow::ListBuilder* lb = static_cast<arrow::ListBuilder *>(builder);
-                        arrow::Int32Builder* ib = static_cast<arrow::Int32Builder *>(lb->value_builder());
+                        // arrow::Int32Builder* ib = static_cast<arrow::Int32Builder *>(lb->value_builder());
 
                         // TODO: extract prev values and append to ib
                         // ib->AppendValues(vector.data(), vector.size());


### PR DESCRIPTION
int32 builder _ib_ is unused as of now and throws a unused-variable warning while building. Commenting it out to avoid the warning till it is further used in implementation.