### PR TITLE
Query arrow data

### DIFF
--- a/src/cls/tabular/cls_tabular_utils.cc
+++ b/src/cls/tabular/cls_tabular_utils.cc
@@ -6509,7 +6509,7 @@ long long int printArrowbufRowAsPyArrowBinary(
 
 
     // add buf len to output
-    int32_t buf_len = static_cast<int32_t>(datasz);
+    uint64_t buf_len = static_cast<uint64_t>(datasz);
     ss.write(reinterpret_cast<const char*>(&buf_len), sizeof(buf_len));
 
     // add const char* arrow buf

--- a/src/progly/query.cc
+++ b/src/progly/query.cc
@@ -216,6 +216,17 @@ static void print_data(const char *dataptr,
                     print_verbose,
                     row_limit - row_counter);
             }
+
+            else if (skyhook_output_format == SkyFormatType::SFT_PYARROW_BINARY) {
+                row_counter += Tables::printArrowbufRowAsPyArrowBinary(
+                    dataptr,
+                    datasz,
+                    print_header,
+                    print_verbose,
+                    row_limit - row_counter
+                );
+            }
+
             else {
                 row_counter += Tables::printArrowbufRowAsCsv(
                     dataptr,


### PR DESCRIPTION
This topic branch contains changes to do two things:

- add the ability to print pyarrow binary for SFT_ARROW formatted data blobs, wrapped in fb_meta flatbuffer structure

- Fix a bug where datasz, in printArrowbufRowAsPyarrowBinary, is cast to an incorrect data type (fix for #98)